### PR TITLE
fix(release): create tarball in /tmp to avoid race condition

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -50,7 +50,7 @@
   "prepare": [
     {
       "path": "@semantic-release/exec",
-      "cmd": "tar --exclude='agentctl-*.tar.gz' -czf agentctl-${nextRelease.version}.tar.gz --exclude='.git' --exclude='tests' --exclude='.github' --exclude='*.md' --exclude='.gitignore' --exclude='node_modules' ."
+      "cmd": "tar -czf /tmp/agentctl-${nextRelease.version}.tar.gz --exclude='.git' --exclude='tests' --exclude='.github' --exclude='*.md' --exclude='.gitignore' --exclude='node_modules' --exclude='agentctl-*.tar.gz' . && mv /tmp/agentctl-${nextRelease.version}.tar.gz ."
     },
     {
       "path": "@semantic-release/exec",


### PR DESCRIPTION
## Summary
Fix the tarball creation to avoid 'file changed as we read it' error by:
1. Creating the tarball in /tmp instead of the current directory
2. Moving it to the working directory after creation

## Problem
The previous approach still had a race condition where tar would detect the file being created during the read operation.

## Solution
Create the tarball in /tmp (completely outside the source tree) and then move it to the working directory.

## Test plan
- [ ] Semantic-release workflow completes successfully
- [ ] Release tarball is created without errors