### PR TITLE
fix(release): configure tag format and improve release notes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": ["main"],
+  "tagFormat": "v${version}",
   "plugins": [
     [
       "@semantic-release/commit-analyzer",
@@ -19,7 +20,12 @@
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "conventionalcommits"
+        "preset": "conventionalcommits",
+        "writerOpts": {
+          "groupBy": "type",
+          "commitGroupsSort": "title",
+          "commitsSort": "header"
+        }
       }
     ],
     [


### PR DESCRIPTION
## Summary
- Add tag format configuration for semantic versioning
- Configure release notes generator to group commits by type
- Create v0.0.0 tag on initial commit so first release will be 0.0.1

## Problem
1. First release was going to be 1.0.0 instead of 0.0.1
2. Release notes weren't grouping features properly

## Solution
1. Created v0.0.0 tag on the initial commit (b4f4532)
2. Semantic-release will now bump to 0.0.1 for the first release
3. Configured release notes generator with better grouping

## Test plan
- [ ] Next release should be v0.0.1
- [ ] Release notes should list all commits grouped by type