### PR TITLE
fix(release): configure for 0.0.x version range

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,10 @@
 {
-  "branches": ["main"],
+  "branches": [
+    {
+      "name": "main",
+      "range": "0.0.x"
+    }
+  ],
   "tagFormat": "v${version}",
   "plugins": [
     [


### PR DESCRIPTION
## Summary
Configure semantic-release to use 0.0.x version range for initial releases.

This ensures the first release will be v0.0.1 instead of v1.0.0.

## Test plan
- [ ] Next release should be v0.0.1
- [ ] Release notes should include all features from develop branch