### PR TITLE
fix(release): use simple branches configuration

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,10 +1,5 @@
 {
-  "branches": [
-    {
-      "name": "main",
-      "range": "0.0.x"
-    }
-  ],
+  "branches": ["main"],
   "tagFormat": "v${version}",
   "plugins": [
     [


### PR DESCRIPTION
## Summary
Fix the branches configuration to use the simple format.

## Problem
The 'range' option in branches configuration is for maintenance branches, not for controlling initial version.

## Solution
Use simple `["main"]` configuration. With v0.0.0 tag present, semantic-release will analyze commits and bump to 0.0.1.

## Commits since v0.0.0
- fix: tarball creation
- fix: release configuration
- chore: dependency updates

These will result in a patch bump: 0.0.0 → 0.0.1 ✓