### PR TITLE
chore: remove develop branch from workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   validate:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   test-macos:


### PR DESCRIPTION
## Summary
Update CI and test workflows to only trigger on main branch since develop branch was removed.

## What Changed
- Updated  to only trigger on main
- Updated  to only trigger on main

## Why
Develop branch was removed in #14, so workflows should only run on main branch.