### PR TITLE
feat: policy engine — per-server tool allow/deny with glob matching

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import { spawnSync } from "child_process";
 import type { Command } from "commander";
 import { loadMcpConfig, loadAgentConfig, loadProviders, resolveProviderConfigPath, expandHome } from "../lib/config";
+import { loadPolicy } from "../lib/policy";
 import { resolveAll, formatForProvider, writeJsonConfig, readTomlConfig, toToml, syncSkills } from "../lib/resolver";
 import type { Provider } from "../lib/schemas";
 
@@ -115,6 +116,18 @@ export function registerSync(program: Command): void {
       if (dryRun) console.log(yellow("DRY RUN — no changes will be made"));
 
       const mcpConfig = loadMcpConfig();
+      const policy = loadPolicy();
+      if (policy?.registryPolicy === "registry-only") {
+        const unverified = Object.keys(mcpConfig).filter(
+          name => !(mcpConfig[name] as any)["registry"]
+        );
+        if (unverified.length > 0) {
+          err(`Sync blocked — policy is registry-only but these servers have no registry field: ${unverified.join(", ")}`);
+          err(`Set policy.registryPolicy to "warn-unverified" or add a registry field to each server.`);
+          process.exit(1);
+        }
+      }
+
       const userConfig = loadAgentConfig();
       const allProviders = loadProviders();
 

--- a/src/lib/policy.ts
+++ b/src/lib/policy.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { AGENTS_DIR, expandHome } from "./config";
+import { PolicySchema, type Policy, type PolicyResult } from "./schemas";
+
+export function loadPolicy(): Policy | null {
+  const path = join(AGENTS_DIR, "policy.json");
+  if (!existsSync(path)) return null;
+  return PolicySchema.parse(JSON.parse(readFileSync(path, "utf-8")));
+}
+
+/** Convert a simple glob pattern (only * as wildcard) to a RegExp. */
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+function matchesAny(patterns: string[], value: string): boolean {
+  return patterns.some(p => globToRegex(p).test(value));
+}
+
+export class PolicyEngine {
+  constructor(private policy: Policy) {}
+
+  checkTool(serverName: string, toolName: string): PolicyResult {
+    const specific = this.policy.servers?.[serverName];
+    const wildcard = this.policy.servers?.["*"];
+
+    // Priority: specific deny > wildcard deny > specific allow > wildcard allow > default
+    if (specific?.tools?.deny  && matchesAny(specific.tools.deny,  toolName)) return "deny";
+    if (wildcard?.tools?.deny  && matchesAny(wildcard.tools.deny,  toolName)) return "deny";
+    if (specific?.tools?.allow && matchesAny(specific.tools.allow, toolName)) return "allow";
+    if (wildcard?.tools?.allow && matchesAny(wildcard.tools.allow, toolName)) return "allow";
+    return this.policy.default;
+  }
+
+  checkPath(serverName: string, filePath: string): PolicyResult {
+    const specific = this.policy.servers?.[serverName];
+    const wildcard = this.policy.servers?.["*"];
+
+    if (specific?.paths?.deny  && specific.paths.deny.some(p => filePath.startsWith(expandHome(p)))) return "deny";
+    if (wildcard?.paths?.deny  && wildcard.paths.deny.some(p => filePath.startsWith(expandHome(p)))) return "deny";
+    if (specific?.paths?.allow && specific.paths.allow.some(p => filePath.startsWith(expandHome(p)))) return "allow";
+    if (wildcard?.paths?.allow && wildcard.paths.allow.some(p => filePath.startsWith(expandHome(p)))) return "allow";
+    return this.policy.default;
+  }
+
+  get registryPolicy() { return this.policy.registryPolicy ?? "allow-unverified"; }
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -135,3 +135,30 @@ export type McpConfig = z.infer<typeof McpConfigSchema>;
 export type AgentConfig = z.infer<typeof AgentConfigSchema>;
 export type Provider = z.infer<typeof ProviderSchema>;
 export type Providers = z.infer<typeof ProvidersSchema>;
+
+// ── Policy ───────────────────────────────────────────────────────────────────
+
+export type PolicyResult = "allow" | "deny" | "ask";
+export type RegistryPolicy = "allow-unverified" | "warn-unverified" | "registry-only";
+
+export const PolicyServerRulesSchema = z.object({
+  tools: z.object({
+    allow: z.array(z.string()).optional(),
+    deny:  z.array(z.string()).optional(),
+  }).optional(),
+  paths: z.object({
+    allow: z.array(z.string()).optional(),
+    deny:  z.array(z.string()).optional(),
+  }).optional(),
+});
+
+export const PolicySchema = z.object({
+  version:        z.literal("1"),
+  default:        z.enum(["allow", "deny", "ask"]),
+  registryPolicy: z.enum(["allow-unverified", "warn-unverified", "registry-only"])
+    .default("allow-unverified"),
+  servers: z.record(z.string(), PolicyServerRulesSchema).optional(),
+});
+
+export type PolicyServerRules = z.infer<typeof PolicyServerRulesSchema>;
+export type Policy = z.infer<typeof PolicySchema>;

--- a/tests/unit/policy.test.ts
+++ b/tests/unit/policy.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "bun:test";
+import { PolicyEngine } from "../../src/lib/policy";
+import type { Policy } from "../../src/lib/schemas";
+
+const strict: Policy = {
+  version: "1",
+  default: "deny",
+  registryPolicy: "warn-unverified",
+  servers: {
+    github: {
+      tools: { allow: ["list_repos", "get_file", "create_issue"], deny: ["delete_repo"] },
+    },
+    "*": {
+      tools: { deny: ["*exec*", "*shell*", "*eval*", "*run*"] },
+    },
+  },
+};
+
+describe("PolicyEngine.checkTool", () => {
+  const engine = new PolicyEngine(strict);
+
+  it("allows an explicitly allowed tool", () => {
+    expect(engine.checkTool("github", "list_repos")).toBe("allow");
+  });
+
+  it("denies an explicitly denied tool on specific server", () => {
+    expect(engine.checkTool("github", "delete_repo")).toBe("deny");
+  });
+
+  it("denies an unlisted tool when default is deny", () => {
+    expect(engine.checkTool("github", "unknown_tool")).toBe("deny");
+  });
+
+  it("denies tool matching wildcard glob on * server", () => {
+    expect(engine.checkTool("filesystem", "execute_shell")).toBe("deny");
+  });
+
+  it("specific server deny beats * server allow", () => {
+    const p: Policy = {
+      version: "1",
+      default: "allow",
+      servers: {
+        github: { tools: { deny: ["delete_repo"] } },
+        "*": { tools: { allow: ["delete_repo"] } },
+      },
+    };
+    expect(new PolicyEngine(p).checkTool("github", "delete_repo")).toBe("deny");
+  });
+
+  it("allows all when default is allow and no rules match", () => {
+    const permissive: Policy = { version: "1", default: "allow" };
+    expect(new PolicyEngine(permissive).checkTool("any", "any_tool")).toBe("allow");
+  });
+});


### PR DESCRIPTION
## Summary

- `src/lib/policy.ts` — `PolicyEngine` with `checkTool` / `checkPath`, `loadPolicy()` reads `~/.agents/policy.json`
- `src/lib/schemas.ts` — `PolicySchema`, `PolicyServerRulesSchema`, `Policy`, `PolicyResult`, `RegistryPolicy` types
- `src/commands/sync.ts` — fail-closed `registry-only` enforcement: blocks sync if any server lacks a `registry` field when policy requires it
- Glob matching: `*` as wildcard, priority: specific deny > wildcard deny > specific allow > wildcard allow > default

## Test plan

- [ ] `bun test tests/unit/policy.test.ts` — 6 pass
- [ ] `bun test tests/unit/` — 20 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)