### PR TITLE
fix: use absolute paths for spawned commands (SonarCloud S4036)

### DIFF
--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -65,6 +65,7 @@ function installSkill(entry: SkillsIndexEntry, targetDir: string): boolean {
     const r = spawnSync("git", ["clone", "--depth", "1", entry.url, dest], {
       encoding: "utf-8",
       stdio: "inherit",
+      env: { ...(process.env as Record<string, string>), PATH: "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin" },
     });
     if (r.status !== 0) {
       console.error(`Failed to clone ${entry.name}`);

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -12,9 +12,11 @@ const ok     = (s: string) => console.log(`  ${green("✓")}  ${s}`);
 const warn   = (s: string) => console.log(`  ${yellow("⚠")}  ${s}`);
 const err    = (s: string) => console.log(`  ${red("✗")}  ${s}`);
 
+const WHICH = "/usr/bin/which";
+
 function detectWatcher(): "fswatch" | "inotifywait" | null {
-  if (spawnSync("which", ["fswatch"], { encoding: "utf-8" }).status === 0) return "fswatch";
-  if (spawnSync("which", ["inotifywait"], { encoding: "utf-8" }).status === 0) return "inotifywait";
+  if (spawnSync(WHICH, ["fswatch"], { encoding: "utf-8" }).status === 0) return "fswatch";
+  if (spawnSync(WHICH, ["inotifywait"], { encoding: "utf-8" }).status === 0) return "inotifywait";
   return null;
 }
 

--- a/src/lib/verify.ts
+++ b/src/lib/verify.ts
@@ -4,8 +4,10 @@ export type VerifyResult =
   | { ok: true; signer: string; source: string }
   | { ok: false; reason: string };
 
+const SAFE_PATH = "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin";
+
 function cmdAvailable(cmd: string): boolean {
-  const r = spawnSync("which", [cmd], { encoding: "utf-8" });
+  const r = spawnSync("/usr/bin/which", [cmd], { encoding: "utf-8", env: { PATH: SAFE_PATH } });
   return r.status === 0;
 }
 
@@ -15,7 +17,7 @@ export function verifyOci(identifier: string): VerifyResult {
   }
   const r = spawnSync("cosign", ["verify", identifier], {
     encoding: "utf-8",
-    env: process.env as Record<string, string>,
+    env: { ...(process.env as Record<string, string>), PATH: SAFE_PATH },
   });
   if (r.status === 0) {
     let signer = "verified";


### PR DESCRIPTION
## Summary

Resolves the 5 remaining SonarCloud security hotspots (rule `typescript:S4036` — unsafe PATH-dependent command resolution):

- `verify.ts`: use `/usr/bin/which` with restricted `PATH` env for `which` and `cosign` calls
- `watch.ts`: use `/usr/bin/which` directly instead of relying on ambient PATH
- `registry.ts`: pass restricted `PATH` env to `git clone` spawn

Restricted PATH used: `/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin`

## Test plan

- [x] All 37 unit tests pass
- [x] SonarCloud should clear all 5 `S4036` hotspots on this branch