### PR TITLE
fix: serialise env/headers as valid TOML inline tables

### DIFF
--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -148,6 +148,14 @@ export function toToml(data: Record<string, unknown>, _indent = 0): string {
   return lines.join("\n");
 }
 
+/** Serialise a flat string-valued record as a TOML inline table: { k = "v", ... } */
+function toTomlInlineTable(obj: Record<string, string>): string {
+  const pairs = Object.entries(obj)
+    .map(([k, v]) => `${k} = ${JSON.stringify(v)}`)
+    .join(", ");
+  return `{ ${pairs} }`;
+}
+
 /**
  * Serialise a record of servers as TOML array-of-tables.
  * Each entry gets a `name` field injected from the record key.
@@ -168,7 +176,7 @@ export function toTomlArrayOfTables(
         if (typeof v === "string") lines.push(`${k} = ${JSON.stringify(v)}`);
         else if (typeof v === "number" || typeof v === "boolean") lines.push(`${k} = ${v}`);
         else if (Array.isArray(v)) lines.push(`${k} = ${JSON.stringify(v)}`);
-        else if (v && typeof v === "object") lines.push(`${k} = ${JSON.stringify(v)}`); // inline table
+        else if (v && typeof v === "object") lines.push(`${k} = ${toTomlInlineTable(v as Record<string, string>)}`);
       }
       return lines.join("\n");
     })

--- a/tests/unit/resolver.test.ts
+++ b/tests/unit/resolver.test.ts
@@ -118,6 +118,20 @@ describe("toTomlArrayOfTables", () => {
     });
     expect(result).toContain('args = ["-y","pkg"]');
   });
+
+  it("serialises env/headers objects as valid TOML inline tables, not JSON", () => {
+    const result = toTomlArrayOfTables("mcp_servers", {
+      github: {
+        transport: "stdio",
+        command: "npx",
+        env: { GITHUB_TOKEN: "ghp_test", NODE_ENV: "production" },
+      },
+    });
+    // Must use TOML inline-table syntax (= not :)
+    expect(result).toContain('env = { GITHUB_TOKEN = "ghp_test", NODE_ENV = "production" }');
+    // Must NOT contain JSON object syntax
+    expect(result).not.toContain('{"GITHUB_TOKEN"');
+  });
 });
 
 describe("writeTomlConfig — array format", () => {


### PR DESCRIPTION
## Summary

- `toTomlArrayOfTables` was serialising object-valued fields (`env`, `headers`) with `JSON.stringify`, producing `{"key":"value"}` notation
- That is valid JSON but **invalid TOML** — Python's `tomllib` rejects it with `Expected '=' after a key`
- Fix adds a `toTomlInlineTable` helper that emits proper TOML inline-table syntax: `{ k = "v", ... }`

## Root cause

```ts
// before — JSON object syntax, not valid TOML
else if (v && typeof v === "object") lines.push(`${k} = ${JSON.stringify(v)}`);

// after — TOML inline table syntax
else if (v && typeof v === "object") lines.push(`${k} = ${toTomlInlineTable(v)}`);
```

## Test plan

- [x] New regression test asserts `env = { KEY = "val" }` format and rejects `{"KEY":` pattern
- [x] Verified `~/.vibe/config.toml` parses cleanly through `python3 -c "import tomllib; tomllib.load(...)"` and Vibe 2.4.2's own Pydantic models
- [x] All 56 tests pass