### PR TITLE
fix: configure release auth and parallelise pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -16,6 +16,27 @@ if git diff --name-only HEAD @{u} 2>/dev/null | grep -q '^src/'; then
   fi
 fi
 
-# Full e2e suite — runs on every push
-# tests/docker/ requires Docker Compose and runs in CI only; explicitly exclude it
-bats --recursive tests/e2e/
+# Skip tests when only non-code files changed (.github/, docs, config files, etc.)
+changed=$(git diff --name-only HEAD @{u} 2>/dev/null)
+if [ -n "$changed" ] && ! echo "$changed" | grep -qE '^(src|tests)/'; then
+  exit 0
+fi
+
+# Prevent SIGPIPE from killing bats when git closes its stdout pipe
+trap '' PIPE
+
+# Run unit tests and e2e suite in parallel; bats --jobs parallelises across test files
+# (requires GNU parallel; falls back to serial bats if not available)
+# tests/docker/ requires Docker Compose — CI only, excluded here
+BATS_FLAGS="--recursive"
+command -v parallel >/dev/null 2>&1 && BATS_FLAGS="--jobs 4 --recursive"
+
+bun test src/ &
+unit_pid=$!
+bats $BATS_FLAGS tests/e2e/ &
+e2e_pid=$!
+
+wait $unit_pid; unit_exit=$?
+wait $e2e_pid; e2e_exit=$?
+
+[ $unit_exit -eq 0 ] && [ $e2e_exit -eq 0 ]


### PR DESCRIPTION
## Summary

- **Release pipeline**: semantic-release was re-releasing `v1.0.0` on every push because `@semantic-release/git` couldn't push its `chore(release)` commit back to `main` — `persist-credentials: false` stripped git auth before the push step. Adds a `Configure git for semantic-release` step that restores the token in the remote URL so the commit lands correctly and future runs find the tag in main's ancestry.
- **Pre-push hook**: fixes SIGPIPE crashes and speeds up local pushes
  - `trap '' PIPE` — prevents bats output overflowing git's pipe from aborting the hook
  - Skip tests entirely when only non-code files changed (`.github/`, docs, etc.)
  - Run `bun test` and `bats` in parallel (uses `--jobs 4` if GNU `parallel` is available)
  - Restore `AGENTS_SECRETS_BACKEND=env` and restrict bats path to `tests/e2e/`

## Test plan

- [ ] Merge to `main` → Release workflow creates `v0.4.1` (not `v1.0.0`)
- [ ] Subsequent push to `main` → Release finds previous tag, computes correct next version
- [ ] Push only `.github/` change locally → hook skips tests and exits immediately
- [ ] Push `src/` change locally → unit + e2e run in parallel, no SIGPIPE