### PR TITLE
fix: update SonarCloud project key to tn819_agentctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 [![CI](https://github.com/tn819/vakt/actions/workflows/ci.yml/badge.svg)](https://github.com/tn819/vakt/actions/workflows/ci.yml)
 [![Tests](https://github.com/tn819/vakt/actions/workflows/test.yml/badge.svg)](https://github.com/tn819/vakt/actions/workflows/test.yml)
-[![Reliability](https://sonarcloud.io/api/project_badges/measure?project=tn819_vakt&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=tn819_vakt)
-[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=tn819_vakt&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=tn819_vakt)
+[![Reliability](https://sonarcloud.io/api/project_badges/measure?project=tn819_agentctl&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=tn819_agentctl)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=tn819_agentctl&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=tn819_agentctl)
 [![Release](https://img.shields.io/github/v/release/tn819/vakt?label=release&color=22c55e)](https://github.com/tn819/vakt/releases)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Bun](https://img.shields.io/badge/runtime-Bun-fbf0df?logo=bun&logoColor=black)](https://bun.sh/)


### PR DESCRIPTION
## Summary
- Updates the two SonarCloud badge URLs in `README.md` from project key `tn819_vakt` to `tn819_agentctl`
- `sonar-project.properties` already used the correct key; this aligns the README badges

## Test Plan
- [ ] Verify SonarCloud badges render correctly after merge