### PR TITLE
fix(ci): open PR for formula update instead of pushing directly to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: v${{ needs.release.outputs.version }}
-          # Need write access to push the updated formula back to this repo
+          # Check out main so the formula commit is based on the current branch
+          # tip. Pushing directly from a detached tag fails GH006 (status checks
+          # not yet run for that commit SHA). PR + auto-merge is the safe path.
+          ref: main
+          fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compute SHAs and update formula
@@ -152,12 +155,27 @@ jobs:
             -e "s/VAKT_SHA256_LINUX_X86_64/${SHA_LINUX_X86_64}/" \
             Formula/vakt.rb
 
-      - name: Commit updated formula to main repo
+      - name: Open PR for formula update
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.release.outputs.version }}
         run: |
+          set -euo pipefail
+          BRANCH="chore/formula-${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add Formula/vakt.rb
           git commit -m "chore(release): update homebrew formula to ${VERSION} [skip ci]"
-          git push origin HEAD:main
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(release): update homebrew formula to ${VERSION}" \
+            --body "Automated formula update for release v${VERSION}.
+
+Updates \`Formula/vakt.rb\` with the correct version and SHA-256 checksums for the published binaries.
+
+_This PR was opened automatically by the release workflow._" \
+            --base main \
+            --head "$BRANCH"
+          # Requires 'Allow auto-merge' enabled in repo Settings → General → Pull Requests.
+          gh pr merge "$BRANCH" --squash --auto --delete-branch


### PR DESCRIPTION
## Problem

The `release-homebrew` job fails with:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 5 of 5 required status checks are expected.
```

It checked out the release tag (detached HEAD) and tried `git push origin HEAD:main`. The new commit has no status check results yet, so GitHub rejects it.

## Fix

Instead of pushing directly:
1. Check out `main` (not the tag) so we start from the current branch tip
2. Create a short-lived branch `chore/formula-${VERSION}`
3. Commit the formula update there
4. Open a PR via `gh pr create`
5. Schedule auto-merge with `gh pr merge --squash --auto --delete-branch`

## One-time repo setting required

**Enable auto-merge in repo settings:**
Settings → General → Pull Requests → ☑ Allow auto-merge

Without this, the `gh pr merge --auto` call will fail. Once enabled, the formula PR will auto-merge as soon as CI passes (the `[skip ci]` commit message skips workflow runs, so required checks complete quickly).

_Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>_