### PR TITLE
fix(ci): replace sed placeholders with pattern-based formula update script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,11 +149,7 @@ jobs:
           SHA_DARWIN_ARM64=$(grep "darwin-arm64" /tmp/checksums/checksums-darwin.txt | awk '{print $1}')
           SHA_LINUX_X86_64=$(grep "linux-x86_64" /tmp/checksums/checksums.txt | awk '{print $1}')
 
-          sed -i \
-            -e "s/VAKT_VERSION/${VERSION}/g" \
-            -e "s/VAKT_SHA256_DARWIN_ARM64/${SHA_DARWIN_ARM64}/" \
-            -e "s/VAKT_SHA256_LINUX_X86_64/${SHA_LINUX_X86_64}/" \
-            Formula/vakt.rb
+          python3 scripts/update-formula.py
 
       - name: Open PR for formula update
         env:

--- a/Formula/vakt.rb
+++ b/Formula/vakt.rb
@@ -1,19 +1,19 @@
 class Vakt < Formula
   desc "Secure MCP runtime — policy, audit, registry, multi-provider sync"
   homepage "https://github.com/tn819/vakt"
-  version "0.5.0"
+  version "0.6.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/tn819/vakt/releases/download/v0.5.0/vakt-0.5.0-darwin-arm64.tar.gz"
-      sha256 "b8896951156bd9c0eadb3da03e6abeef57cbecb2bc14f5a02732f55f8709b8e2"
+      url "https://github.com/tn819/vakt/releases/download/v0.6.0/vakt-0.6.0-darwin-arm64.tar.gz"
+      sha256 "a0ef2341cea721f53e87da2e6d01f419eb4dc1d2413e821c80c6100b64f1b815"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/tn819/vakt/releases/download/v0.5.0/vakt-0.5.0-linux-x86_64.tar.gz"
-      sha256 "01b9e086f9f60fb8a4fd125bbc73d11d894397c2e15efec80b880b57fc0dfc1f"
+      url "https://github.com/tn819/vakt/releases/download/v0.6.0/vakt-0.6.0-linux-x86_64.tar.gz"
+      sha256 "85a68f3c6654926f4b99b38c5c0562e8643a1a982f43f4a1da9903319782c7a2"
     end
   end
 

--- a/scripts/update-formula.py
+++ b/scripts/update-formula.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Update Formula/vakt.rb with new version and checksums.
+
+Reads VERSION, SHA_DARWIN_ARM64, SHA_LINUX_X86_64 from environment.
+"""
+import re
+import os
+import sys
+
+version    = os.environ['VERSION']
+sha_darwin = os.environ['SHA_DARWIN_ARM64']
+sha_linux  = os.environ['SHA_LINUX_X86_64']
+
+with open('Formula/vakt.rb') as f:
+    content = f.read()
+
+content = re.sub(r'version "[^"]*"', f'version "{version}"', content)
+content = re.sub(
+    r'(on_arm do\s+url ")[^"]*(".*?sha256 ")[^"]*(")',
+    lambda m: (
+        f'{m.group(1)}https://github.com/tn819/vakt/releases/download/'
+        f'v{version}/vakt-{version}-darwin-arm64.tar.gz'
+        f'{m.group(2)}{sha_darwin}{m.group(3)}'
+    ),
+    content, flags=re.DOTALL)
+content = re.sub(
+    r'(on_intel do\s+url ")[^"]*(".*?sha256 ")[^"]*(")',
+    lambda m: (
+        f'{m.group(1)}https://github.com/tn819/vakt/releases/download/'
+        f'v{version}/vakt-{version}-linux-x86_64.tar.gz'
+        f'{m.group(2)}{sha_linux}{m.group(3)}'
+    ),
+    content, flags=re.DOTALL)
+
+with open('Formula/vakt.rb', 'w') as f:
+    f.write(content)
+
+print(f"Updated formula to v{version}")


### PR DESCRIPTION
## Summary

Follows up on #95. The `release-homebrew` job was still failing at `git commit` with "nothing to commit" because the `sed` substitution looked for placeholder strings (`VAKT_VERSION` etc.) that no longer exist in `Formula/vakt.rb` after the first release.

## Fix

- Adds `scripts/update-formula.py` — a Python script that uses regex to replace the existing version/URLs/SHAs in the formula regardless of what values are currently there
- Updates the workflow to call the script instead of `sed`
- Updates `Formula/vakt.rb` to v0.6.0 with correct checksums (fixing the drift from the failed homebrew job)