### PR TITLE
chore(release): update homebrew formula to 0.6.4

### DIFF
--- a/Formula/vakt.rb
+++ b/Formula/vakt.rb
@@ -1,19 +1,19 @@
 class Vakt < Formula
   desc "Secure MCP runtime — policy, audit, registry, multi-provider sync"
   homepage "https://github.com/tn819/vakt"
-  version "0.6.2"
+  version "0.6.4"
 
   on_macos do
     on_arm do
-      url "https://github.com/tn819/vakt/releases/download/v0.6.2/vakt-0.6.2-darwin-arm64.tar.gz"
-      sha256 "3a594046ba3f48c78d5a31445a14a186e823820424bb216dc62b0faad190c9d8"
+      url "https://github.com/tn819/vakt/releases/download/v0.6.4/vakt-0.6.4-darwin-arm64.tar.gz"
+      sha256 "872a29d43a663e4dbf9e02829b283fe2a2651b2cd78c3a624d2a68a44f3ae136"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/tn819/vakt/releases/download/v0.6.2/vakt-0.6.2-linux-x86_64.tar.gz"
-      sha256 "c9181ec9dc0f0c53a7647491146616cf2d3abeb5ac66eb90d9c6c6c09fc9b58f"
+      url "https://github.com/tn819/vakt/releases/download/v0.6.4/vakt-0.6.4-linux-x86_64.tar.gz"
+      sha256 "38a4a3ba99a18727393a23db43256055ac459e8fd82a003aa06ca0f681b70094"
     end
   end
 


### PR DESCRIPTION
Automated formula update for release v0.6.4.

Updates `Formula/vakt.rb` with the correct version and SHA-256 checksums for the published binaries.

_This PR was opened automatically by the release workflow._