### PR TITLE
chore(release): update homebrew formula to 0.7.0

### DIFF
--- a/Formula/vakt.rb
+++ b/Formula/vakt.rb
@@ -1,19 +1,19 @@
 class Vakt < Formula
   desc "Secure MCP runtime — policy, audit, registry, multi-provider sync"
   homepage "https://github.com/tn819/vakt"
-  version "0.6.2"
+  version "0.7.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/tn819/vakt/releases/download/v0.6.2/vakt-0.6.2-darwin-arm64.tar.gz"
-      sha256 "3a594046ba3f48c78d5a31445a14a186e823820424bb216dc62b0faad190c9d8"
+      url "https://github.com/tn819/vakt/releases/download/v0.7.0/vakt-0.7.0-darwin-arm64.tar.gz"
+      sha256 "704c73fd22ffbb89fe8c7fab3eed60ee9dab2a3c5d9293a08cb456408cdd0078"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/tn819/vakt/releases/download/v0.6.2/vakt-0.6.2-linux-x86_64.tar.gz"
-      sha256 "c9181ec9dc0f0c53a7647491146616cf2d3abeb5ac66eb90d9c6c6c09fc9b58f"
+      url "https://github.com/tn819/vakt/releases/download/v0.7.0/vakt-0.7.0-linux-x86_64.tar.gz"
+      sha256 "a09f4eaff9a5e9752472d80aba2e4ca06771c087949e81082ab0d8af0cd05171"
     end
   end
 


### PR DESCRIPTION
Automated formula update for release v0.7.0.

Updates `Formula/vakt.rb` with the correct version and SHA-256 checksums for the published binaries.

_This PR was opened automatically by the release workflow._