### PR TITLE
chore(release): update homebrew formula to 0.8.0

### DIFF
--- a/Formula/vakt.rb
+++ b/Formula/vakt.rb
@@ -1,19 +1,19 @@
 class Vakt < Formula
   desc "Secure MCP runtime — policy, audit, registry, multi-provider sync"
   homepage "https://github.com/tn819/vakt"
-  version "0.7.0"
+  version "0.8.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/tn819/vakt/releases/download/v0.7.0/vakt-0.7.0-darwin-arm64.tar.gz"
-      sha256 "704c73fd22ffbb89fe8c7fab3eed60ee9dab2a3c5d9293a08cb456408cdd0078"
+      url "https://github.com/tn819/vakt/releases/download/v0.8.0/vakt-0.8.0-darwin-arm64.tar.gz"
+      sha256 "6d08494b75946349243e689ad93c9f7de3e4a31f8e408c5fc281649beddb052b"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/tn819/vakt/releases/download/v0.7.0/vakt-0.7.0-linux-x86_64.tar.gz"
-      sha256 "a09f4eaff9a5e9752472d80aba2e4ca06771c087949e81082ab0d8af0cd05171"
+      url "https://github.com/tn819/vakt/releases/download/v0.8.0/vakt-0.8.0-linux-x86_64.tar.gz"
+      sha256 "9178d3f23ca8dc40a1ed5a62b526861ffb3a7a79bb22d368cc25565dfdefebb5"
     end
   end
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -7,7 +7,9 @@ const config: KnipConfig = {
   entry: ["scripts/*.ts", "src/**/*.test.ts"],
   project: ["src/**/*.ts", "scripts/**/*.ts"],
   ignoreBinaries: [
-    "bats", // system test runner, not a package
+    "bats",   // system test runner, not a package
+    "eslint", // called in scripts, provided by devDependency eslint
+    "knip",   // called in scripts, provided by devDependency knip
   ],
   ignore: [
     "src/lib/verify.ts", // pending feat/wire-verify-supply-chain


### PR DESCRIPTION
Automated formula update for release v0.8.0.

Updates `Formula/vakt.rb` with the correct version and SHA-256 checksums for the published binaries.

_This PR was opened automatically by the release workflow._