### PR TITLE
fix(ci): remove [skip ci] from formula PR commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add Formula/vakt.rb
-          git commit -m "chore(release): update homebrew formula to ${VERSION} [skip ci]"
+          git commit -m "chore(release): update homebrew formula to ${VERSION}"
           git push --force origin "$BRANCH"
           BODY="Automated formula update for release v${VERSION}.\n\nUpdates \`Formula/vakt.rb\` with the correct version and SHA-256 checksums for the published binaries.\n\n_This PR was opened automatically by the release workflow._"
           gh pr create \


### PR DESCRIPTION
## Summary
- Removes `[skip ci]` from the formula branch commit message in `release-homebrew`
- Every formula PR was blocked from merging because required checks (build, test, lint, sonarcloud, security) never ran

## Root cause
Two places use `[skip ci]` in the release pipeline:
1. **`.releaserc`** — on the semantic-release CHANGELOG commit pushed to main. **Intentional**: prevents an infinite CI loop when semantic-release pushes back to main.
2. **`release.yml`** (this fix) — on the formula branch commit. **Not intentional**: blocked required checks on every formula PR.

## Test plan
- [ ] Next release: formula PR should show CI checks running and auto-merge once they pass